### PR TITLE
Update to own fork of react-native-gesture-handler

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,7 @@ import {
   Gesture,
   GestureDetector,
   GestureHandlerRootView,
-} from 'react-native-gesture-handler';
+} from '@gg66/react-native-gesture-handler';
 
 const styles = StyleSheet.create({
   container: {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * @format
  */
 
-import 'react-native-gesture-handler';
+import '@gg66/react-native-gesture-handler';
 import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -485,7 +485,7 @@ PODS:
     - React-jsi (= 0.72.4)
     - React-logger (= 0.72.4)
     - React-perflogger (= 0.72.4)
-  - RNGestureHandler (2.13.0):
+  - RNGestureHandler (2.13.3):
     - React-Core
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
@@ -555,7 +555,7 @@ DEPENDENCIES:
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - "RNGestureHandler (from `../node_modules/@gg66/react-native-gesture-handler`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -654,7 +654,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNGestureHandler:
-    :path: "../node_modules/react-native-gesture-handler"
+    :path: "../node_modules/@gg66/react-native-gesture-handler"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -709,11 +709,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 4941cc1b3cf08b792fbf666342c9fc95f1969035
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
-  RNGestureHandler: 6e4dc6b7ab3a385386d4e36228bd065e5a611394
+  RNGestureHandler: 108080b69be900d64a22e2826771a8808ffcb48a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 5de9ac1912c4d27c08f4d1da82dd87339674871e
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.72.4",
-    "react-native-gesture-handler": "^2.13.0"
+    "@gg66/react-native-gesture-handler": "2.13.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,17 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.49.0.tgz#86f79756004a97fa4df866835093f1df3d03c333"
   integrity sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==
 
+"@gg66/react-native-gesture-handler@2.13.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@gg66/react-native-gesture-handler/-/react-native-gesture-handler-2.13.3.tgz#bc6417e3cb72922c82678031a94f2d31f15771f5"
+  integrity sha512-z3npkruvKGRPhWWVA8V6ZfYpi0cIMFOQPFOpJHvfnvsCOe4PPRjktFT1inY/X0ehOodhrAIbOlTx/tj5/gnhmg==
+  dependencies:
+    "@egjs/hammerjs" "^2.0.17"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -6046,17 +6057,6 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-native-gesture-handler@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.13.0.tgz#326f52c0e2172200225ee0c7f7534b8ffe122ec4"
-  integrity sha512-SkUAEEkSjfML24nDepgrcLzPhMyUrPOESpFLMAYmiMBsy+QJBfEs12KF5B4mMVUKBdlXQ/BQ2VA3CP29hh16lA==
-  dependencies:
-    "@egjs/hammerjs" "^2.0.17"
-    hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
-    lodash "^4.17.21"
-    prop-types "^15.7.2"
 
 react-native@0.72.4:
   version "0.72.4"


### PR DESCRIPTION
This uses https://github.com/ggilles/react-native-gesture-handler where I simply circumvent the bug introduced by running under Detox, needed until https://github.com/wix-incubator/DetoxSync/pull/68 is merged or we find another solution.